### PR TITLE
Core/Auras: Spirit of Redemption #4130

### DIFF
--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -9407,6 +9407,10 @@ InventoryResult Player::CanEquipItem(uint8 slot, uint16& dest, Item* pItem, bool
 
                 if (IsNonMeleeSpellCasted(false))
                     return EQUIP_ERR_CANT_DO_RIGHT_NOW;
+
+                // prevent equip item in Spirit of Redemption (Aura: 27827)
+                if (HasAuraType(SPELL_AURA_SPIRIT_OF_REDEMPTION))
+                    return EQUIP_ERR_CANT_DO_RIGHT_NOW;
             }
 
             uint8 eslot = FindEquipSlot(pProto, slot, swap);

--- a/src/game/Spell.cpp
+++ b/src/game/Spell.cpp
@@ -4435,6 +4435,10 @@ SpellCastResult Spell::CheckCast(bool strict)
         // check if target is in combat
         if (non_caster_target && m_spellInfo->HasAttribute(SPELL_ATTR_EX_NOT_IN_COMBAT_TARGET) && target->isInCombat())
             return SPELL_FAILED_TARGET_AFFECTING_COMBAT;
+
+        // check if target is affected by Spirit of Redemption (Aura: 27827)
+        if (target->HasAuraType(SPELL_AURA_SPIRIT_OF_REDEMPTION))
+            return SPELL_FAILED_BAD_TARGETS;
     }
     // zone check
     uint32 zone, area;

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -5792,7 +5792,13 @@ void Aura::HandleSpiritOfRedemption(bool apply, bool Real)
                 target->SetStandState(UNIT_STAND_STATE_STAND);
         }
 
-        target->SetHealth(1);
+        // interrupt casting when entering Spirit of Redemption
+        if (target->IsNonMeleeSpellCasted(false))
+            target->InterruptNonMeleeSpells(false);
+
+        // set health and mana to maximum
+        target->SetHealth(target->GetMaxHealth());
+        target->SetPower(POWER_MANA, target->GetMaxPower(POWER_MANA));
     }
     // die at aura end
     else


### PR DESCRIPTION
https://report.nostalrius.org/plugins/tracker/?aid=4130

* You can no longer equip or swap items while in Spirit of Redemption
* Spirit of Redemption can no longer be a target for actions (spell casts)
* Interrupt current casted spell when entering Spirit of Redemption
* Set health and mana to maximum when entering Spirit of Redemption