### PR TITLE
Core/Spells: Blessing of Protection missing SpellSpecific

### DIFF
--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -494,7 +494,7 @@ SpellSpecific GetSpellSpecific(uint32 spellId)
             if (IsSealSpell(spellInfo))
                 return SPELL_SEAL;
 
-            if (spellInfo->IsFitToFamilyMask(UI64LIT(0x0000000010000100)))
+            if (spellInfo->IsFitToFamilyMask(UI64LIT(0x0000000010000180)))
                 return SPELL_BLESSING;
 
             if (spellInfo->IsFitToFamilyMask(UI64LIT(0x00000820180400)) && spellInfo->HasAttribute(SPELL_ATTR_EX3_UNK9))


### PR DESCRIPTION
https://report.nostalrius.org/plugins/tracker/?aid=4166
* Blessing of Protection is now considered as Blessing
* Blessing of Protection now overrides Blessing of Freedom and vice versa