### PR TITLE
DB/SpellBonus: Paladin Consecration AP Scaling

### DIFF
--- a/sql/updates/mangos/new/2016_03_09_01_world.sql
+++ b/sql/updates/mangos/new/2016_03_09_01_world.sql
@@ -1,0 +1,2 @@
+-- DB/SpellCoefficient: Paladin - Consecration
+UPDATE `spell_bonus_data` SET `ap_dot_bonus`=0 WHERE `entry`=26573;


### PR DESCRIPTION
https://report.nostalrius.org/plugins/tracker/?aid=4162
* Paladin - Consecration no longer scales with attack power