### PR TITLE
Core/Spells: Swiftmend healing ticks

### DIFF
--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -2992,7 +2992,7 @@ void Spell::EffectHeal(SpellEffectIndex /*eff_idx*/)
             }
 
             int32 tickheal = targetAura->GetModifier()->m_amount;
-            int32 tickcount = GetSpellDuration(targetAura->GetSpellProto()) / targetAura->GetSpellProto()->EffectAmplitude[idx] - 1;
+            int32 tickcount = GetSpellDuration(targetAura->GetSpellProto()) / targetAura->GetSpellProto()->EffectAmplitude[idx];
 
             unitTarget->RemoveAurasDueToSpell(targetAura->GetId());
 


### PR DESCRIPTION
Issue #4318 is invalid - Details are wrong here. Swiftmend was healing tickCount - 1 before this change.