### PR TITLE
Core/Unit: Break stealth on damage

### DIFF
--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -554,11 +554,13 @@ void Unit::DealDamageMods(Unit* pVictim, uint32& damage, uint32* absorb)
 
 uint32 Unit::DealDamage(Unit* pVictim, uint32 damage, CleanDamage const* cleanDamage, DamageEffectType damagetype, SpellSchoolMask damageSchoolMask, SpellEntry const* spellProto, bool durabilityLoss)
 {
-    // remove affects from attacker at any non-DoT damage (including 0 damage)
+    // remove affects from attacker at any damage (including 0 damage)
+    if (damagetype != SELF_DAMAGE_ROGUE_FALL)
+        RemoveSpellsCausingAura(SPELL_AURA_MOD_STEALTH);
+
+    // ... non-DoT damage
     if (damagetype != DOT)
     {
-        if (damagetype != SELF_DAMAGE_ROGUE_FALL)
-            RemoveSpellsCausingAura(SPELL_AURA_MOD_STEALTH);
         RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
 
         if (pVictim->GetTypeId() == TYPEID_PLAYER && !pVictim->IsStandState() && !pVictim->hasUnitState(UNIT_STAT_STUNNED))


### PR DESCRIPTION
https://report.nostalrius.org/plugins/tracker/?aid=4307
* Damage (even if absorbed) should always break stealth auras.