### PR TITLE
Core/Unit: Grounding Totem fixes

### DIFF
--- a/src/game/Totem.cpp
+++ b/src/game/Totem.cpp
@@ -213,7 +213,7 @@ bool Totem::IsImmuneToSpellEffect(SpellEntry const* spellInfo, SpellEffectIndex 
     if (!IsPositiveSpell(spellInfo))
     {
         // immune to all negative auras
-        if (IsAuraApplyEffect(spellInfo, index))
+        if (IsAuraApplyEffect(spellInfo, index) && !IsMagnet())
             return true;
     }
     else

--- a/src/game/Unit.cpp
+++ b/src/game/Unit.cpp
@@ -5693,11 +5693,18 @@ Unit* Unit::SelectMagnetTarget(Unit* victim, Spell* spell, SpellEffectIndex eff)
         {
             if (Unit* magnet = (*itr)->GetCaster())
             {
-                if (magnet->isAlive() && magnet->IsWithinLOSInMap(this) && spell->CheckTarget(magnet, eff))
+                if (magnet->isAlive() && spell->CheckTarget(magnet, eff))
                 {
-                    if (SpellAuraHolder* holder = (*itr)->GetHolder())
-                        if (holder->DropAuraCharge())
-                            victim->RemoveSpellAuraHolder(holder);
+                    // only drop charge if spell is not delayed
+                    if (!spell->m_spellInfo->speed)
+                        if (SpellAuraHolder* holder = (*itr)->GetHolder())
+                            if (holder->DropAuraCharge())
+                            {
+                                victim->RemoveSpellAuraHolder(holder);
+                                if (victim->IsMagnet())
+                                    static_cast<Totem*>(victim)->UnSummon();
+                            }
+                                
                     return magnet;
                 }
             }

--- a/src/game/Unit.h
+++ b/src/game/Unit.h
@@ -1985,6 +1985,8 @@ class MANGOS_DLL_SPEC Unit : public WorldObject
         bool isMoving() const { return m_movementInfo.HasMovementFlag(movementFlagsMask); }
         bool isMovingOrTurning() const { return m_movementInfo.HasMovementFlag(movementOrTurningFlagsMask); }
 
+        bool IsMagnet() const { return GetEntry() == 5925; } /// @todo: find a more generic solution (Grounding Totem)
+
     protected:
         explicit Unit();
 


### PR DESCRIPTION
* Grounding Totem can now redirect multiple flying spells
* Grounding Totem can now be destroyed by non damage spells
* Grounding Totem can now redirect spells with exclusions (e.g. only humanoids)
* Grounding Totem can now redirect chain spells such as Chain Lightning

https://report.nostalrius.org/plugins/tracker/?aid=4442